### PR TITLE
add config overlay for biometric sensors

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -520,4 +520,13 @@
 
     <!-- Whether or not wcg mode should be enabled on this device -->
     <bool name="config_enableWcgMode">true</bool>
+
+    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
+         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
+         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
+         and Strength as defined in Authenticators.java -->
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <!-- ID0:Face:Strong -->
+        <item>0:8:15</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Related to GrapheneOS/os_issue_tracker#325 and GrapheneOS/os_issue_tracker#326

0:8:15 is the value found in the product overlays for the coral and flame factory images. However, I don't have those devices, so this hasn't been tested to see if they fix the linked issues.