### PR TITLE
reverted change to product properties

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -945,10 +945,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/init.recovery.device.rc:recovery/root/init.recovery.coral.rc \
     $(LOCAL_PATH)/init.recovery.device.rc:recovery/root/init.recovery.flame.rc
 
-# Oslo feature flag
-PRODUCT_PRODUCT_PROPERTIES += \
-    ro.vendor.aware_available=true
-
 QTI_TELEPHONY_UTILS := qti-telephony-utils
 QTI_TELEPHONY_UTILS += qti_telephony_utils.xml
 PRODUCT_PACKAGES += $(QTI_TELEPHONY_UTILS)


### PR DESCRIPTION
As discussed in https://github.com/GrapheneOS/os_issue_tracker/issues/241#issuecomment-704186025, I wish to revert the changes to product properties so that AOD becomes an option again for Pixel4 devices.