### PR TITLE
Enable BUILD_BROKEN_DUP_RULES to work around APV

### DIFF
--- a/BoardConfig-common.mk
+++ b/BoardConfig-common.mk
@@ -17,6 +17,8 @@
 include build/make/target/board/BoardConfigMainlineCommon.mk
 include build/make/target/board/BoardConfigPixelCommon.mk
 
+BUILD_BROKEN_DUP_RULES := true
+
 TARGET_BOARD_PLATFORM := msmnile
 TARGET_BOARD_INFO_FILE := device/google/coral/board-info.txt
 USES_DEVICE_GOOGLE_CORAL := true


### PR DESCRIPTION
Change-Id: I2ce59d7d35c53cd203dc7d4858041a30f8f00719