### PR TITLE
Revert "Enable BUILD_BROKEN_DUP_RULES to work around APV"

### DIFF
--- a/BoardConfig-common.mk
+++ b/BoardConfig-common.mk
@@ -17,8 +17,6 @@
 include build/make/target/board/BoardConfigMainlineCommon.mk
 include build/make/target/board/BoardConfigPixelCommon.mk
 
-BUILD_BROKEN_DUP_RULES := true
-
 TARGET_BOARD_PLATFORM := msmnile
 TARGET_BOARD_INFO_FILE := device/google/coral/board-info.txt
 USES_DEVICE_GOOGLE_CORAL := true


### PR DESCRIPTION
This reverts commit a3e9ea8e5344022e830bf9cf4e0ee066979e2c80.