### PR TITLE
Revert "Use inline carrier extraction"

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -128,7 +128,3 @@ PRODUCT_PACKAGES += \
 # sysconfig XML from stock
 PRODUCT_COPY_FILES += \
 	$(LOCAL_PATH)/product-sysconfig-stock.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/sysconfig/product-sysconfig-stock.xml
-
-PRODUCT_PACKAGES += \
-    extracted-carrierconfig \
-    extracted-apns

--- a/device.mk
+++ b/device.mk
@@ -39,8 +39,7 @@ PRODUCT_SOONG_NAMESPACES += \
     vendor/qcom/sm8150/proprietary/qmi \
     vendor/qcom/sm8150/codeaurora/location \
     vendor/google/interfaces \
-    vendor/google_nos/test/system-test-harness \
-    vendor/carriersettings-extractor
+    vendor/google_nos/test/system-test-harness
 
 # Include sensors soong namespace
 PRODUCT_SOONG_NAMESPACES += \


### PR DESCRIPTION
This reverts commit b09f9ba9be89e5d63e493178e45f17ad7e9d0c88.